### PR TITLE
Make sorted interface more rubyish

### DIFF
--- a/lib/list.rb
+++ b/lib/list.rb
@@ -61,16 +61,18 @@ class List
   private
 
   attr_reader :options
-  attr_accessor :head_node, :size
+  attr_accessor :head_node, :size, :comparator
 
   def maintain_sort_order?
     sort_option = options[:sorted]
-    raise ArgumentError(sort_option) unless [ 0, 1, nil ].member?(sort_option)
-    sort_option == 1
+    if sort_option.is_a?(Proc)
+      self.comparator = sort_option
+    end
+    !!sort_option
   end
 
   def sorted_insert(object)
-    additional_node = Node.new(object)
+    additional_node = new_node(object, comparator)
     if empty?
       self.head_node = additional_node
 
@@ -94,7 +96,7 @@ class List
   end
 
   def append(object)
-    additional_node = Node.new(object)
+    additional_node = new_node(object, comparator)
     if empty?
       self.head_node = additional_node
     else
@@ -105,5 +107,9 @@ class List
       current_node.next = additional_node
     end
     additional_node
+  end
+
+  def new_node(object, comparator)
+    Node.new(object, comparator)
   end
 end

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -1,15 +1,18 @@
 class Node
   include Comparable
 
-  attr_reader :object
+  DEFAULT_COMPARATOR = Proc.new { |a, b| a <=> b }
+
+  attr_reader :object, :comparator
   attr_accessor :next
 
-  def initialize(object)
+  def initialize(object, comparator)
     @object = object
+    @comparator = comparator || DEFAULT_COMPARATOR
     @next = nil
   end
 
   def <=>(other)
-    object <=> other.object
+    comparator.call(object, other.object)
   end
 end

--- a/test/list_test.rb
+++ b/test/list_test.rb
@@ -9,7 +9,7 @@ describe List do
 
   describe "#add" do
     describe "with regular list" do
-      let(:list) { List.new(sorted: 0) }
+      let(:list) { List.new(sorted: false) }
 
       it "should add elements to end of list" do
         list.length.must_equal 0
@@ -26,7 +26,7 @@ describe List do
     end
 
     describe "with sorted list" do
-      let(:list) { List.new(sorted: 1) }
+      let(:list) { List.new(sorted: true) }
 
       it "should add elements based on sort order" do
         list.length.must_equal 0
@@ -47,6 +47,32 @@ describe List do
         list.elements.must_equal(['alf', 'bar', 'baz', 'foo', 'zed'])
       end
     end
+
+    describe 'with custom comparator' do
+      # reverse comparator
+      let(:comparator) { Proc.new { |a, b| b <=> a } }
+      let(:list) { List.new(sorted: comparator) }
+
+      it "should add elements based on sort order" do
+        list.length.must_equal 0
+
+        list.add('foo')
+        list.elements.must_equal(['foo'])
+
+        list.add('bar')
+        list.elements.must_equal(['foo', 'bar'])
+
+        list.add('baz')
+        list.elements.must_equal(['foo', 'baz', 'bar'])
+
+        list.add('zed')
+        list.elements.must_equal(['zed', 'foo', 'baz', 'bar'])
+
+        list.add('alf')
+        list.elements.must_equal(['zed', 'foo', 'baz', 'bar', 'alf'])
+      end
+    end
+
   end
 
   describe '#length' do


### PR DESCRIPTION
Sanjay,

Here is another PR that shows my thoughts on the `:sorted` interface. Assuming we won't get into trouble by breaking our public interface for the LinkedList class, I think we should change the interface to behave this way:

Any truthy value for `#sorted` should result in a sorted linked list.
Any falsey value should return in a standard linked list.

And as an extra fun challenge, we could optionally pass a Proc object to support custom sort orders.

What do you think?

/-Matt